### PR TITLE
update for 0.17

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -39,7 +39,7 @@ exports.config = {
   paths: {
     // Dependencies and current project directories to watch
     watched: [
-      "web/static",
+      "web/static/",
       "test/static"
     ],
 
@@ -51,7 +51,7 @@ exports.config = {
   plugins: {
     babel: {
       // Do not use ES6 compiler in vendor code
-      ignore: [/web\/static\/vendor/]
+      ignore: [/web\/static\/vendor/, /web\/static\/elm/]
     },
     elmBrunch: {
       // Set to path where elm-package.json is located, defaults to project root (optional)

--- a/web/static/elm/Component/Editor/API.elm
+++ b/web/static/elm/Component/Editor/API.elm
@@ -1,7 +1,4 @@
-module Component.Editor.API (..) where
-
-
-import Component.Editor.Update exposing (update, Action(..), Addresses)
+module Component.Editor.API exposing (..) -- where
 
 
 initialText =
@@ -10,7 +7,3 @@ initialText =
 
 Put [markdown](https://daringfireball.net/projects/markdown/) text here.
 """
-
-editorMailbox : Signal.Mailbox Action
-editorMailbox =
-  Signal.mailbox NoOp

--- a/web/static/elm/Component/Editor/Main.elm
+++ b/web/static/elm/Component/Editor/Main.elm
@@ -1,4 +1,4 @@
-module Component.Editor.Main where
+module Component.Editor.Main exposing (..) -- where
 
 import Html exposing (Html)
 import StartApp

--- a/web/static/elm/Component/Editor/Main.elm
+++ b/web/static/elm/Component/Editor/Main.elm
@@ -1,36 +1,25 @@
 module Component.Editor.Main exposing (..) -- where
 
 import Html exposing (Html)
-import StartApp
-import Effects exposing (Never)
-import Task exposing (Task)
-
-import Component.Editor.Update exposing (update, Action(..), Addresses)
+import Html.App as Html
+import Component.Editor.Update exposing (update)
 import Component.Editor.Model exposing (Model)
 import Component.Editor.View exposing (view)
-import Component.Editor.API exposing (editorMailbox, initialText)
+import Component.Editor.API exposing (initialText)
 
-app : StartApp.App (Model {})
-app =
-  let
-    initModel : Model {}
-    initModel =
-      { inputText = initialText }
-
-    modelWithEffects =
-      ( initModel, Effects.none )
-
-    addresses =
-      { editor = editorMailbox.address }
-  in
-    StartApp.start
-      { init = modelWithEffects
-      , view = (view addresses)
-      , update = (update addresses)
-      , inputs = [ editorMailbox.signal ]
-      }
-
-
-main : Signal Html
 main =
-  app.html
+    let
+        initModel : Model {}
+        initModel =
+            { inputText = initialText }
+
+        modelWithEffects =
+            (initModel, Cmd.none)
+
+    in
+        Html.program
+            { init = modelWithEffects
+            , view = view
+            , update = update
+            , subscriptions = (\_ -> Sub.none)
+            }

--- a/web/static/elm/Component/Editor/Model.elm
+++ b/web/static/elm/Component/Editor/Model.elm
@@ -1,5 +1,4 @@
-module Component.Editor.Model (..) where
-
+module Component.Editor.Model exposing(..) -- where
 
 type alias Model a =
   { a

--- a/web/static/elm/Component/Editor/Update.elm
+++ b/web/static/elm/Component/Editor/Update.elm
@@ -1,25 +1,18 @@
-module Component.Editor.Update (..) where
+module Component.Editor.Update exposing (..) -- where
 
-import Effects exposing (Effects)
 import Component.Editor.Model exposing (..)
 
 
-type Action
+type Msg
   = NoOp
   | ModifyText String
 
 
-type alias Addresses a =
-  { a
-  | editor : Signal.Address Action
-  }
-
-
-update : Addresses a -> Action -> Model b -> ( Model b, Effects.Effects Action )
-update addresses action model =
+update : Msg -> Model b -> ( Model b, Cmd Msg )
+update action model =
   case action of
     NoOp ->
-      ( model, Effects.none )
+      ( model, Cmd.none )
 
     ModifyText str ->
-      ( { model | inputText = str }, Effects.none )
+      ( { model | inputText = str }, Cmd.none )

--- a/web/static/elm/Component/Editor/View.elm
+++ b/web/static/elm/Component/Editor/View.elm
@@ -19,7 +19,7 @@ view model =
         [ div
             [ class "pure-u-1-2 edit" ]
             [ textarea
-                [ value (Debug.log "text" model.inputText)
+                [ value model.inputText
                 , onInput ModifyText
                 , class "inputarea"
                 ]

--- a/web/static/elm/Component/Editor/View.elm
+++ b/web/static/elm/Component/Editor/View.elm
@@ -1,17 +1,16 @@
-module Component.Editor.View (..) where
+module Component.Editor.View exposing (..) -- where
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Signal
 import Markdown
 
 import Component.Editor.Model exposing (..)
 import Component.Editor.Update exposing (..)
 
 
-view : Addresses a -> Signal.Address dontcare -> Model b -> Html
-view addresses _ model =
+view : Model a -> Html Msg
+view model =
   div
     [ class "view" ]
     [ h1 [] [ text "Elm Markdown Editor" ]
@@ -20,14 +19,14 @@ view addresses _ model =
         [ div
             [ class "pure-u-1-2 edit" ]
             [ textarea
-                [ value model.inputText
-                , on "input" targetValue (Signal.message addresses.editor << ModifyText)
+                [ value (Debug.log "text" model.inputText)
+                , onInput ModifyText
                 , class "inputarea"
                 ]
                 []
             ]
         , div
             [ class "pure-u-1-2 display" ]
-            [ Markdown.toHtml model.inputText ]
+            [ Markdown.toHtmlWith Markdown.defaultOptions  [] (model.inputText) ]
         ]
     ]

--- a/web/static/elm/Creator/API.elm
+++ b/web/static/elm/Creator/API.elm
@@ -1,6 +1,0 @@
-module Creator.API where
-
-import Creator.Update exposing (..)
-
-creatorMailbox : Signal.Mailbox Action
-creatorMailbox = Signal.mailbox NoOp

--- a/web/static/elm/Creator/Main.elm
+++ b/web/static/elm/Creator/Main.elm
@@ -1,47 +1,28 @@
-module Creator.Main where
+module Creator.Main exposing (..) -- where
 
 import Html exposing (Html)
-import StartApp
-import Effects exposing (Never)
-import Task exposing (Task)
+import Html.App as Html
 
 import Creator.Update exposing (router, MessageRouter(..))
 import Creator.Model exposing (Model)
 import Creator.View exposing (view)
-import Creator.API exposing (..)
-import Component.Editor.API exposing (initialText, editorMailbox)
+import Component.Editor.API exposing (initialText)
 
 
-
-app : StartApp.App Model
-app =
+main =
     let
         initModel : Model
         initModel =
             { inputText = initialText }
 
         modelWithEffects =
-            (initModel, Effects.none)
+            (initModel, Cmd.none)
 
-        addresses =
-            { editor = editorMailbox.address
-            , top = creatorMailbox.address
-            }
     in
-        StartApp.start
+        Html.program
             { init = modelWithEffects
-            , view = (view addresses)
-            , update = (router addresses)
-            , inputs =
-              [ Signal.map (EditorLevel) editorMailbox.signal
-              , Signal.map (TopLevel) creatorMailbox.signal
-              ]
+            , view = view
+            , update = router
+            , subscriptions = (\_ -> Sub.none)
             }
 
-main : Signal Html
-main =
-    app.html
-
-port tasks : Signal (Task.Task Never ())
-port tasks =
-    app.tasks

--- a/web/static/elm/Creator/Model.elm
+++ b/web/static/elm/Creator/Model.elm
@@ -1,4 +1,4 @@
-module Creator.Model where
+module Creator.Model exposing (..)
 
 import Component.Editor.Model as EditorModel
 

--- a/web/static/elm/Creator/Update.elm
+++ b/web/static/elm/Creator/Update.elm
@@ -1,26 +1,20 @@
-module Creator.Update where
+module Creator.Update exposing (..) -- where
 
-import Effects exposing (Effects)
 import Creator.Model exposing (..)
 import Component.Editor.Update as EditorUpdate
 
-type Action
+type Msg
   = NoOp
 
-type alias Addresses =
-  { editor : Signal.Address EditorUpdate.Action
-  , top : Signal.Address Action
-  }
-
 type MessageRouter
-  = TopLevel Action
-  | EditorLevel EditorUpdate.Action
+  = TopLevel Msg
+  | EditorLevel EditorUpdate.Msg
 
-update : Addresses -> Action -> Model -> (Model, Effects.Effects Action)
-update addresses action model =
+update : Msg -> Model -> (Model, Cmd Msg)
+update action model =
   case action of
     NoOp ->
-      (model, Effects.none)
+      (model, Cmd.none)
 
 
 {-| We use this router for composing our actions and components together
@@ -28,19 +22,21 @@ Each component provides an API which is scoped through MessageRouter.
 In order for cross-component communication, we expose the addresses to each component.
 From there, they can trigger Actions elsehwere.
 -}
-router : Addresses -> MessageRouter -> Model -> (Model, Effects.Effects MessageRouter)
-router addresses route model =
+router : MessageRouter -> Model -> (Model, Cmd MessageRouter)
+router route model =
   case route of
     TopLevel action ->
       let
-        (model, effect) =
-          update addresses action model
+        (model', effect) =
+          update action model
       in
-        ( model, Effects.map (TopLevel) effect )
+        ( model', Cmd.map (TopLevel) effect )
 
     EditorLevel action ->
       let
-        (model, effect) =
-          EditorUpdate.update addresses action model
+        _ =
+          Debug.log "here" model
+        (model', effect) =
+          EditorUpdate.update action model
       in
-        ( model, Effects.map (EditorLevel) effect )
+        ( model', Cmd.map (EditorLevel) effect )

--- a/web/static/elm/Creator/Update.elm
+++ b/web/static/elm/Creator/Update.elm
@@ -17,10 +17,8 @@ update action model =
       (model, Cmd.none)
 
 
-{-| We use this router for composing our actions and components together
+{-| We use this router for composing our messages and components together
 Each component provides an API which is scoped through MessageRouter.
-In order for cross-component communication, we expose the addresses to each component.
-From there, they can trigger Actions elsehwere.
 -}
 router : MessageRouter -> Model -> (Model, Cmd MessageRouter)
 router route model =
@@ -34,8 +32,6 @@ router route model =
 
     EditorLevel action ->
       let
-        _ =
-          Debug.log "here" model
         (model', effect) =
           EditorUpdate.update action model
       in

--- a/web/static/elm/Creator/View.elm
+++ b/web/static/elm/Creator/View.elm
@@ -12,7 +12,4 @@ import Component.Editor.View as EditorView
 
 view : Model -> Html MessageRouter
 view model =
-    let
-        _ = Debug.log "model" model
-    in
-        Html.map (EditorLevel) (EditorView.view model)
+    Html.map EditorLevel (EditorView.view model)

--- a/web/static/elm/Creator/View.elm
+++ b/web/static/elm/Creator/View.elm
@@ -1,15 +1,18 @@
-module Creator.View (..) where
+module Creator.View exposing (..) -- where
 
+import Html.App as Html
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Signal
 
 import Creator.Model exposing (..)
 import Creator.Update exposing (..)
 import Component.Editor.View as EditorView
 
 
-view : Addresses -> Signal.Address dontcare -> Model -> Html
-view addresses _ model =
-    EditorView.view addresses addresses.editor model
+view : Model -> Html MessageRouter
+view model =
+    let
+        _ = Debug.log "model" model
+    in
+        Html.map (EditorLevel) (EditorView.view model)

--- a/web/static/elm/elm-package.json
+++ b/web/static/elm/elm-package.json
@@ -8,11 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
-        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
-        "evancz/elm-markdown": "2.0.1 <= v < 3.0.0",
-        "evancz/start-app": "2.0.2 <= v < 3.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-markdown": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -21,4 +21,4 @@ import "phoenix_html"
 // import socket from "./socket"
 
 const elmDiv = document.querySelector("#elm-container");
-const elmApp = Elm.embed(Elm.Creator.Main, elmDiv);
+const elmApp = Elm.Creator.Main.embed(elmDiv);


### PR DESCRIPTION
- Upgrades everything to work with 0.17!

I uncovered two bugs while porting:
- `Bitwise.js` needs to be wrapped like other native modules to stop build tools going crazy -> https://github.com/elm-lang/core/pull/570
- Markdown doesn't apply diffs correctly -> once https://github.com/evancz/elm-markdown/pull/18 is merged, then the markdown element will work as before
